### PR TITLE
fix: inquiry list의 경로가 API 문서와 같도록 수정

### DIFF
--- a/functions/api/routes/inquiry/index.js
+++ b/functions/api/routes/inquiry/index.js
@@ -1,8 +1,8 @@
 const express = require('express');
 const router = express.Router();
 
-router.get('/', require('./inquiryListGET'));
+router.get('/list', require('./inquiryListGET'));
 router.get('/schedule', require('./inquiryScheduleGET'));
-router.get('/profile',require('./inquiryUserGET'));
-router.post('/create',require('./inquiryCreatePOST'));
+router.get('/profile', require('./inquiryUserGET'));
+router.post('/create', require('./inquiryCreatePOST'));
 module.exports = router;


### PR DESCRIPTION
서버 선생님들 안녕하세요!! 야심한 시각에 인사드립니다. .

지난주 열심히 작업해주시고 문서도 친절하게 작성해주셔서 저희 클라이언트도 열성을 다해 작업하고 있습니다!!

클라이언트 작업 중 다음과 같이 전체 목록을 조회할 때 404 Not Found가 발생했습니다. 
```json
// 20211201021336
// https://asia-northeast3-doosungpaper-1bf1e.cloudfunctions.net/api/inquiry/list?start=2021-11-02&end=2021-12-16

{
  "status": 404,
  "success": false,
  "message": "잘못된 경로입니다."
}
```

inquiryRouter의 `/`에서 `inquiryListGET` 작업을 하고 있더군요!
/api/inquiry로 요청을 보내면 잘 작동했습니다

더미데이터 엄청 꼼꼼하게 많이 넣어주셨더라구요.. 👍👍 홍식이 두식이의 소원 저도 이뤄지길 기도하고 있겠습니다!!
```json
// 20211201021804
// https://asia-northeast3-doosungpaper-1bf1e.cloudfunctions.net/api/inquiry?start=2021-11-02&end=2021-12-16

{
  "status": 200,
  "success": true,
  "message": "조회 성공",
  "data": [
    {
      "title": "대량구매 관련 문의",
      "date": "2021-11-25T16:52:35.187Z",
      "status": false
    }, ...
```

API 명세를 수정하셔서 /api/inquiry?...로 요청했을 때 이 응답이 오는 것으로 하시거나, 이 PR을 받아주시고 다시 배포해주시거나, 배포 서버에서 터미널 vim에디터로 이 부분을 수정해주신다면 좋을 것 같습니다!! 다시 배포하는게 번거로우실 수 있으니 정말 편하게 하셔도 됩니다!!